### PR TITLE
Add GitHub Actions workflow for automated cross-platform releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,207 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*' # Trigger on tags like v1.0, v2.3.4
+
+jobs:
+  # Placeholder for Windows build job
+  build_windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x' # Or specify your project's Python version
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run build script
+        run: python build.py
+
+      - name: Upload Windows Executable
+        uses: actions/upload-artifact@v4
+        with:
+          name: Repo-Save-Manager-Windows-exe # Artifact name for internal transfer
+          path: dist/Repo Save Manager.exe
+
+  # Placeholder for Linux build job
+  build_linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x' # Or specify your project's Python version
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Install Linux packaging tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y dpkg-dev fakeroot patchelf desktop-file-utils libgl1-mesa-glx libegl1-mesa libxcb-xinerama0 libxcb-cursor0 libxkbcommon-x11-0 libxcb-randr0 libxcb-image0 libxcb-icccm4 libxcb-keysyms1 libxcb-render-util0
+          # Download linuxdeploy and appimagetool
+          wget -c https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -O linuxdeploy.AppImage
+          wget -c https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O appimagetool.AppImage
+          chmod +x linuxdeploy.AppImage appimagetool.AppImage
+          sudo mv linuxdeploy.AppImage /usr/local/bin/linuxdeploy
+          sudo mv appimagetool.AppImage /usr/local/bin/appimagetool
+
+      - name: Run build script (generates .deb and PyInstaller exec for AppImage)
+        run: python build.py
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }} # Pass the tag to build.py
+
+      - name: Create AppImage
+        run: |
+          # The PyInstaller executable is at dist/Repo Save Manager
+          # linuxdeploy will create an AppDir
+          # Use the .desktop file and icon from the .deb build process or create them anew for AppImage
+          # For simplicity, let's assume build.py placed a suitable icon where linuxdeploy can find it
+          # or linuxdeploy can find it from the system if the .deb was installed (not the case here)
+
+          # We need a .desktop file for linuxdeploy. build.py creates one for the .deb,
+          # let's copy it or create a similar one for the AppImage.
+          # Assuming build.py created 'dist/repo-save-manager_VERSION_ARCH/usr/share/applications/repo-save-manager.desktop'
+          # and an icon 'dist/repo-save-manager_VERSION_ARCH/usr/share/icons/hicolor/128x128/apps/repo-save-manager.png'
+          # This part is tricky as build.py's .deb paths are internal to the .deb staging dir.
+
+          # Let's create a minimal .desktop file for AppImage specifically
+          APP_NAME="Repo Save Manager"
+          LOWER_APP_NAME="repo-save-manager"
+          APPDIR_PATH="AppDir" # linuxdeploy default output
+          mkdir -p "${APPDIR_PATH}/usr/share/applications/"
+          mkdir -p "${APPDIR_PATH}/usr/share/icons/hicolor/128x128/apps/"
+
+          # Create .desktop file for AppImage
+          cat <<EOF > "${APPDIR_PATH}/usr/share/applications/${LOWER_APP_NAME}.desktop"
+          [Desktop Entry]
+          Version=1.0
+          Name=${APP_NAME}
+          Comment=Manage repository saves
+          Exec=AppRun # This will point to the script linuxdeploy creates
+          Icon=${LOWER_APP_NAME}
+          Terminal=false
+          Type=Application
+          Categories=Utility;Development;
+          EOF
+
+          # Copy icon (try reburger.png, then reburger.ico)
+          ICON_SOURCE=""
+          if [ -f "reburger.png" ]; then
+            ICON_SOURCE="reburger.png"
+          elif [ -f "reburger.ico" ]; then
+            ICON_SOURCE="reburger.ico"
+          fi
+
+          if [ -n "$ICON_SOURCE" ]; then
+            cp "$ICON_SOURCE" "${APPDIR_PATH}/usr/share/icons/hicolor/128x128/apps/${LOWER_APP_NAME}.png" # Convert/copy to .png
+          else
+            echo "Warning: No icon found for AppImage."
+          fi
+
+          # Run linuxdeploy
+          # The executable from PyInstaller is at 'dist/Repo Save Manager'
+          # The --appimage-extract-and-run is important for AppImage-based tools
+          APPIMAGE_EXTRACT_AND_RUN=1 linuxdeploy --appdir "${APPDIR_PATH}"            -e "dist/Repo Save Manager"            -d "${APPDIR_PATH}/usr/share/applications/${LOWER_APP_NAME}.desktop"            -i "${APPDIR_PATH}/usr/share/icons/hicolor/128x128/apps/${LOWER_APP_NAME}.png"            --output appimage
+
+          # appimagetool will be called by linuxdeploy if --output appimage is used and appimagetool is found
+          # If not, one might need to call it explicitly:
+          # APPIMAGE_EXTRACT_AND_RUN=1 appimagetool "${APPDIR_PATH}"
+          # This should create Repo_Save_Manager-x86_64.AppImage or similar in current dir.
+          # Rename it to a more standard name for upload.
+          # The name linuxdeploy generates can be a bit complex. Let's find it.
+          # It usually includes APPNAME-ARCH.AppImage.
+          # For PyInstaller bundled apps, linuxdeploy might not need to bundle many Qt libs if PyI got them.
+
+          # Verify AppImage exists (name might vary slightly based on linuxdeploy version)
+          # Common pattern: Name from .desktop-ARCH.AppImage or ExecutableName-ARCH.AppImage
+          # Let's assume linuxdeploy creates "Repo_Save_Manager-x86_64.AppImage" or similar.
+          # We will find it and rename it.
+          find . -name "Repo_Save_Manager*.AppImage" -exec mv {} "dist/Repo-Save-Manager-Linux.AppImage" \;
+
+        env:
+          APPIMAGE_EXTRACT_AND_RUN: 1 # For running AppImage based tools
+          # VERSION: ${{ github.ref_name }} # linuxdeploy might use this if available via env
+
+      - name: Upload Linux Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Repo-Save-Manager-Linux-Artifacts
+          path: |
+            dist/*.deb
+            dist/*.AppImage
+          retention-days: 7 # Optional: how long to keep workflow artifacts
+
+  create_release:
+    needs: [build_windows, build_linux] # Run after both builds complete
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to create a release
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts/ # Download all artifacts to this directory
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Windows Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./artifacts/Repo-Save-Manager-Windows-exe/Repo Save Manager.exe # Corrected path to the downloaded artifact
+          asset_name: Repo-Save-Manager-${{ github.ref_name }}-Windows.exe
+          asset_content_type: application/octet-stream
+
+      - name: Find .deb file
+        id: find_deb
+        run: |
+          DEB_FILE=$(find artifacts/Repo-Save-Manager-Linux-Artifacts -name "*.deb" -type f)
+          echo "Found .deb: $DEB_FILE"
+          echo "filepath=$DEB_FILE" >> $GITHUB_OUTPUT
+
+      - name: Upload Linux .deb Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          # Path will be artifacts/Repo-Save-Manager-Linux-Artifacts/THE_DEB_FILE.deb
+          # We need to find the .deb file name. It includes version and arch.
+          asset_path: ${{ steps.find_deb.outputs.filepath }} # This will be set by a new step
+          asset_name: Repo-Save-Manager-${{ github.ref_name }}-Linux.deb # Simplified name for release
+          asset_content_type: application/vnd.debian.binary-package
+        id: upload_deb
+
+      - name: Upload Linux .AppImage Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          # Path will be artifacts/Repo-Save-Manager-Linux-Artifacts/THE_APPIMAGE_FILE.AppImage
+          asset_path: artifacts/Repo-Save-Manager-Linux-Artifacts/Repo-Save-Manager-Linux.AppImage # Path to the AppImage after download and rename
+          asset_name: Repo-Save-Manager-${{ github.ref_name }}.AppImage # Simplified name for release
+          asset_content_type: application/x-appimage
+        id: upload_appimage

--- a/build.py
+++ b/build.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """
 Build script for Repo Save Manager
-This script packages the application using PyInstaller
+This script packages the application using PyInstaller and creates .deb packages on Linux.
 """
 
 import os
 import sys
 import shutil
 import subprocess
+import platform
 
 def clean_build_directories():
     """Clean up the dist, build, and __pycache__ directories"""
@@ -20,24 +21,23 @@ def clean_build_directories():
                 shutil.rmtree(directory)
             except Exception as e:
                 print(f"Warning: Could not fully clean {directory}: {e}")
-                # Try to clean as much as possible
                 try:
                     for root, dirs, files in os.walk(directory):
-                        for file in files:
+                        for file_path in files: # Renamed to avoid conflict
                             try:
-                                os.remove(os.path.join(root, file))
+                                os.remove(os.path.join(root, file_path))
                             except:
-                                pass
+                                pass # nosec
                 except:
-                    pass
+                    pass # nosec
     
-    # Also clean .spec files
-    for file in os.listdir('.'):
-        if file.endswith('.spec'):
+    # Also clean .spec files and version_info.txt
+    for item in os.listdir('.'):
+        if item.endswith('.spec') or item == "version_info.txt":
             try:
-                os.remove(file)
+                os.remove(item)
             except Exception as e:
-                print(f"Warning: Could not remove {file}: {e}")
+                print(f"Warning: Could not remove {item}: {e}")
 
 def create_version_info():
     """Create version info file for Windows executable"""
@@ -81,64 +81,221 @@ VSVersionInfo(
     return version_file
 
 def run_pyinstaller():
-    """Run PyInstaller with the spec file to create a single file executable"""
+    """Run PyInstaller to create the executable, adapting for OS."""
     print("Running PyInstaller...")
-    version_file = create_version_info()
+    current_os = platform.system()
     
-    # Make sure the icon file exists
-    icon_path = "reburger.ico"
-    if not os.path.exists(icon_path):
-        print(f"Warning: Icon file not found at {icon_path}")
-    else:
-        print(f"Using icon file: {icon_path}")
+    icon_path_windows = "reburger.ico"
+    icon_path_linux = "reburger.png" # Prefer .png for Linux
+
+    cmd = ["pyinstaller", "--onefile", "--name=Repo Save Manager", "--clean", "--noconfirm", "--hidden-import=pycryptodome"]
+
+    if current_os == "Windows":
+        version_file = create_version_info()
+        if not os.path.exists(icon_path_windows):
+            print(f"Warning: Windows icon file not found at {icon_path_windows}")
+            icon_to_use = None
+        else:
+            print(f"Using icon file: {icon_path_windows}")
+            icon_to_use = icon_path_windows
+
+        cmd.extend(["--windowed", f"--version-file={version_file}"])
+        if icon_to_use:
+            cmd.extend([f"--icon={icon_to_use}", "--add-data", f"{icon_to_use};."])
+
+    elif current_os == "Linux":
+        if os.path.exists(icon_path_linux):
+            print(f"Using icon file: {icon_path_linux}")
+            icon_to_use = icon_path_linux
+        elif os.path.exists(icon_path_windows):
+            print(f"Warning: Linux icon {icon_path_linux} not found, falling back to {icon_path_windows}")
+            icon_to_use = icon_path_windows
+        else:
+            print(f"Warning: No icon file found ({icon_path_linux} or {icon_path_windows})")
+            icon_to_use = None
+
+        if icon_to_use:
+             cmd.extend([f"--icon={icon_to_use}", "--add-data", f"{icon_to_use};."])
     
-    # Build the command with all necessary options
-    cmd = [
-        "pyinstaller",
-        "--onefile",
-        "--windowed",  # No console window
-        f"--icon={icon_path}",
-        f"--version-file={version_file}",
-        "--name=Repo Save Manager",
-        "--clean",  # Clean PyInstaller cache
-        "--noconfirm",  # Replace output directory without asking
-        "--add-data", f"{icon_path};.",  # Include icon file in the executable
-        "--hidden-import=pycryptodome",  # Ensure crypto library is included
-        "repo_save_manager.py"
-    ]
-    
-    # If lib directory exists, include it
+    cmd.append("repo_save_manager.py")
+
     if os.path.exists("lib"):
-        cmd.extend(["--add-data", "lib;lib"])
-    
-    # Run PyInstaller
+        cmd.extend(["--add-data", "lib:lib"])
+
     print(f"Running command: {' '.join(cmd)}")
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     
     if result.returncode != 0:
         print("Error running PyInstaller:")
-        print(result.stderr)
+        print("STDOUT:", result.stdout)
+        print("STDERR:", result.stderr)
         sys.exit(1)
     print("PyInstaller completed successfully.")
 
+def create_deb_package(version_tag):
+    """Create a .deb package for Linux."""
+    print(f"Creating .deb package for version {version_tag}...")
+    app_name = "repo-save-manager"
+    version = version_tag.lstrip('v')
+
+    try:
+        arch_result = subprocess.run(['dpkg', '--print-architecture'], capture_output=True, text=True, check=True)
+        arch = arch_result.stdout.strip()
+    except (FileNotFoundError, subprocess.CalledProcessError) as e:
+        print(f"Error getting architecture: {e}. Defaulting to 'amd64'.")
+        arch = "amd64" # Fallback for environments where dpkg might not be available during testing
+
+    package_name_versioned = f"{app_name}_{version}_{arch}"
+    package_build_dir = os.path.join("dist", package_name_versioned) # Root of .deb structure
+
+    # Clean up previous build attempt for this version
+    if os.path.exists(package_build_dir):
+        shutil.rmtree(package_build_dir)
+
+    debian_dir = os.path.join(package_build_dir, "DEBIAN")
+    usr_bin_dir = os.path.join(package_build_dir, "usr", "bin")
+    app_install_dir = os.path.join(package_build_dir, "opt", app_name)
+    desktop_entry_dir = os.path.join(package_build_dir, "usr", "share", "applications")
+
+    # Determine icon path and name
+    icon_source_linux = "reburger.png"
+    icon_source_fallback = "reburger.ico"
+    app_icon_name_in_package = f"{app_name}.png" # Standardize to .png in package
+
+    icon_install_path_str = "usr/share/icons/hicolor/128x128/apps" # Relative path for .desktop
+    icon_install_dir_abs = os.path.join(package_build_dir, icon_install_path_str)
+
+
+    os.makedirs(debian_dir, exist_ok=True)
+    os.makedirs(usr_bin_dir, exist_ok=True)
+    os.makedirs(app_install_dir, exist_ok=True)
+    os.makedirs(desktop_entry_dir, exist_ok=True)
+    os.makedirs(icon_install_dir_abs, exist_ok=True)
+
+    control_content = f"""Package: {app_name}
+Version: {version}
+Section: utils
+Priority: optional
+Architecture: {arch}
+Maintainer: SemiWork <dev@example.com>
+Description: Repo Save Manager - A tool to manage repository saves.
+ This package contains the Repo Save Manager application.
+Depends: python3, python3-pyqt6, libgl1, libxkbcommon-x11-0, libxcb-cursor0, libxcb-randr0, libxcb-image0, libxcb-icccm4, libxcb-keysyms1, libxcb-render-util0
+""" # Added more common Qt/XCB deps
+    with open(os.path.join(debian_dir, "control"), "w", encoding="utf-8") as f:
+        f.write(control_content)
+
+    pyinstaller_output_name = "Repo Save Manager" # Name given in PyInstaller
+    shutil.copy(os.path.join("dist", pyinstaller_output_name), os.path.join(app_install_dir, "RepoSaveManager")) # Standardized name in /opt
+
+    launcher_path = os.path.join(usr_bin_dir, app_name)
+    launcher_content = f"""#!/bin/sh
+/opt/{app_name}/RepoSaveManager "$@"
+"""
+    with open(launcher_path, "w", encoding="utf-8") as f:
+        f.write(launcher_content)
+    os.chmod(launcher_path, 0o755)
+
+    actual_icon_source = None
+    if os.path.exists(icon_source_linux):
+        actual_icon_source = icon_source_linux
+    elif os.path.exists(icon_source_fallback):
+        actual_icon_source = icon_source_fallback
+        print(f"Warning: Using fallback icon {icon_source_fallback} for .deb package.")
+
+    if actual_icon_source:
+        shutil.copy(actual_icon_source, os.path.join(icon_install_dir_abs, app_icon_name_in_package))
+        icon_field_for_desktop_file = os.path.join("/", icon_install_path_str, app_icon_name_in_package) # Absolute path for Icon field
+    else:
+        print("Warning: No icon file (reburger.png or reburger.ico) found for .deb package.")
+        icon_field_for_desktop_file = app_name # Let the system try to find a generic one
+
+    desktop_content = f"""[Desktop Entry]
+Version=1.0
+Name=Repo Save Manager
+Comment=Manage repository saves
+Exec={app_name}
+Icon={icon_field_for_desktop_file}
+Terminal=false
+Type=Application
+Categories=Utility;Development;
+"""
+    with open(os.path.join(desktop_entry_dir, f"{app_name}.desktop"), "w", encoding="utf-8") as f:
+        f.write(desktop_content)
+
+    deb_file_path = os.path.join("dist", f"{package_name_versioned}.deb")
+    print(f"Building .deb package: {package_build_dir} -> {deb_file_path}")
+    try:
+        subprocess.run(["dpkg-deb", "--build", package_build_dir, deb_file_path], check=True)
+        print(f".deb package created successfully: {deb_file_path}")
+        return deb_file_path
+    except subprocess.CalledProcessError as e:
+        print(f"Error building .deb package: {e}")
+        sys.exit(1)
+    except FileNotFoundError:
+        print("Error: dpkg-deb command not found. Is it installed and in PATH?")
+        sys.exit(1)
+
+
+def prepare_for_appimage():
+    """Ensure the Linux executable from PyInstaller is ready for AppImage creation."""
+    print("Preparing for AppImage build...")
+    linux_executable_path = os.path.join("dist", "Repo Save Manager") # As named by PyInstaller
+
+    if not os.path.exists(linux_executable_path):
+        print(f"Error: Linux executable not found at {linux_executable_path} for AppImage preparation.")
+        sys.exit(1)
+
+    print(f"Linux executable for AppImage is ready at: {os.path.abspath(linux_executable_path)}")
+    # The actual AppImage creation will be done by linuxdeploy in the GitHub workflow
+    return linux_executable_path
+
 def verify_executable():
-    """Verify the executable exists"""
-    exe_path = os.path.join("dist", "Repo Save Manager.exe")
+    """Verify the main executable exists after PyInstaller run."""
+    current_os = platform.system()
+    exe_name = "Repo Save Manager" # This is the --name given to PyInstaller
+    if current_os == "Windows":
+        exe_name += ".exe" # PyInstaller adds .exe on Windows automatically
+
+    exe_path = os.path.join("dist", exe_name)
+
     if os.path.exists(exe_path):
-        print(f"Executable created successfully: {os.path.abspath(exe_path)}")
+        print(f"Executable verified: {os.path.abspath(exe_path)}")
         print(f"Size: {os.path.getsize(exe_path) / 1024 / 1024:.2f} MB")
     else:
-        print(f"Warning: Executable not found at {exe_path}")
+        print(f"Error: Main executable not found at {exe_path} after PyInstaller run.")
+        sys.exit(1)
 
 def main():
-    """Main build process"""
+    """Main build process for Windows and Linux."""
     print("Starting build process for Repo Save Manager...")
+    version_tag = os.environ.get("GITHUB_REF_NAME", "v0.0.0-localtest") # GITHUB_REF_NAME is like 'refs/tags/v1.2.3'
+
+    # Extract tag if GITHUB_REF_NAME is a full ref path
+    if version_tag.startswith("refs/tags/"):
+        version_tag = version_tag.replace("refs/tags/", "")
+
+    current_os = platform.system()
+
     clean_build_directories()
     run_pyinstaller()
-    verify_executable()
-    print("Build process completed successfully.")
-    print("\nExecutable is available at:")
-    print(f"  - EXE: {os.path.abspath(os.path.join('dist', 'Repo Save Manager.exe'))}")
+    verify_executable() # Verify after pyinstaller, before OS-specific packaging
+
+    if current_os == "Linux":
+        print("\nStarting Linux-specific packaging...")
+        deb_file = create_deb_package(version_tag)
+        appimage_input_executable = prepare_for_appimage() # This just verifies exe and prints path
+        print("\nLinux packaging completed.")
+        if deb_file: # create_deb_package returns path or None
+            print(f"  - DEB: {os.path.abspath(deb_file)}")
+        print(f"  - AppImage input (PyInstaller exec): {os.path.abspath(appimage_input_executable)}")
+
+    elif current_os == "Windows":
+        print("\nWindows build completed.")
+        # verify_executable already printed the path for Windows if successful
+        print(f"  - EXE: {os.path.abspath(os.path.join('dist', 'Repo Save Manager.exe'))}")
+
+    print("\nBuild process completed successfully overall.")
 
 if __name__ == "__main__":
-    main() 
+    main()


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow that automates the creation of release artifacts for Windows and Linux.

The workflow (`.github/workflows/release.yml`) triggers on version tags (e.g., v1.0.0) and performs the following:

1.  Builds the Windows executable using PyInstaller.
2.  Builds on Linux:
    - Creates a standalone executable using PyInstaller.
    - Packages a .deb file.
    - Generates an .AppImage using linuxdeploy.
3.  Creates a GitHub Release and uploads the generated .exe, .deb, and .AppImage files as release assets.

The `build.py` script has been substantially updated to:
- Differentiate between Windows and Linux build processes.
- Include logic for creating .deb packages (control file, desktop entry, icon installation, launcher script, and dpkg-deb execution).
- Prepare the PyInstaller output for AppImage generation.
- Standardize icon handling and versioning from Git tags.